### PR TITLE
Revert "Bump tornado from 6.4.2 to 6.5.1 in /.github/workflows in the pip group across 1 directory"

### DIFF
--- a/.github/workflows/mkdocs-requirements.txt
+++ b/.github/workflows/mkdocs-requirements.txt
@@ -15,4 +15,4 @@ PyYAML==6.0.2
 repackage==0.7.3
 six==1.16.0
 termcolor==2.4.0
-tornado==6.5.1
+tornado==6.4.2


### PR DESCRIPTION
Reverts niyajali/compose-signature#2