### PR TITLE
Bug: Draw signature after drawing background

### DIFF
--- a/src/commonMain/kotlin/com/niyajali/compose/sign/ComposeSign.kt
+++ b/src/commonMain/kotlin/com/niyajali/compose/sign/ComposeSign.kt
@@ -157,10 +157,11 @@ public fun ComposeSign(
                     }
                 }
                 .drawWithContent {
-                    drawContent()
-
                     // Draw background
                     drawRect(config.backgroundColor)
+
+                    // Draw signature
+                    drawContent()
 
                     // Draw grid if enabled
                     if (config.showGrid) {


### PR DESCRIPTION
The signature was not showing up no matter what. The reason was the drawing of signature in `drawWithContent` was before the drawing of the background. This caused the background to be drawn over the signature. By moving the `drawContent()` after `drawRect(config.backgroundColor)`, this allows the signature to now show up again.